### PR TITLE
Raml mocker bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raml-server",
   "description": "Run a server based on RAML files .. zero coding",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": {
     "name": "Franco Arolfo",
     "email": "francoarolfo@hotmail.com"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "json-server": "^0.7.11",
-    "raml-mocker": "^0.1.12",
+    "raml-mocker": "^0.2.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {},


### PR DESCRIPTION
Raml-mocker moved to a new version, and the last one fails silently, at least on Mac OS X. Bump seams to fix the issue 😀

Tested on Mac OS X 10.11.4 Beta, Node v5.9.0
