### PR TITLE
increased priority of example over schema

### DIFF
--- a/ramlServer.js
+++ b/ramlServer.js
@@ -21,9 +21,17 @@ var options = {
 function reqToDBEntry(request) {
     var resource = request.uri.substr(1),
         obj = {};
-    obj[resource] = request.mock == undefined
-      ? {}
-      : request.mock();
+
+    var response = {};
+    if ( request.example != undefined && request.example() != undefined ) {
+      response = JSON.parse( request.example() );
+    } else if ( request.mock != undefined ) {
+      response = request.mock();
+    } else {
+      response = {};
+    }
+
+    obj[resource] = response;
     return obj;
 }
 


### PR DESCRIPTION
If example was provided for endpoint it will be used prior mocked response by provided schema. It is useful for custom non trivial responses  
