### PR TITLE
ability to specify folder with .raml has been added

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "json-server": "^0.7.11",
     "raml-mocker": "^0.2.4",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "yargs" : "^4.7.1"
   },
   "devDependencies": {},
   "homepage": "https://github.com/farolfo/raml-server",

--- a/ramlServer.js
+++ b/ramlServer.js
@@ -8,10 +8,11 @@
 
 var ramlMocker = require('raml-mocker'),
     _ = require('underscore'),
-    jsonServer = require('json-server');
+    jsonServer = require('json-server'),
+    argv = require('yargs').argv;;
 
 var options = {
-        path: '.'
+        path: argv.path || '.'
     },
     mocksAmount = 10,
     port = process.env.PORT || 3000,


### PR DESCRIPTION
added yargs npm dependency
--path argument now allows to specify the location of .raml file

example:

```
$ node ramlServer.js --path /tmp/raml-server/
$ raml-server --path /tmp/raml-server/
```
