### PR TITLE
Upgrade raml-mocker depencency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "json-server": "^0.7.11",
-    "raml-mocker": "^0.2.4",
+    "raml-mocker": "^0.2.6",
     "underscore": "^1.8.3",
     "yargs" : "^4.7.1"
   },


### PR DESCRIPTION
The underlying faker library on raml-mocker has been updated to no longer return
arrays, but strings. This causes raml-mocker to do `.join(' ')` on a string,
breaking the whole mock.
