### PR TITLE
Exit on SIGTERM

### DIFF
--- a/ramlServer.js
+++ b/ramlServer.js
@@ -60,3 +60,7 @@ function generateServer(db) {
 ramlMocker.generate(options, function (requestsToMock) {
     generateServer(_.reduce(_.map(requestsToMock, reqToDBEntry), _.extend, {}));
 });
+
+process.on('SIGTERM', function() {
+    process.exit();
+});


### PR DESCRIPTION
I'm running raml-server as a Docker container, and it would be very nice if it listens on the SIGTERM signal, so the process can be properly controlled by Docker.
