### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ This is done by generating responses' data reading the JSON schemas with the [RA
 * RAML 1.0.
 * Start a server based on the ```api.raml``` file that is on the current directory if no argument is provided.
 
-###As seen at
+### As seen at
 
 * http://www.programmableweb.com/news/standalone-raml-api-mocking-tools-surface/2015/08/13


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
